### PR TITLE
Fix graph api error by updating the call for creating onlineMeeting. …

### DIFF
--- a/Source/FY19GraphShowcaseDemo/MeetingCaptureWebApp/Helpers/GraphService.cs
+++ b/Source/FY19GraphShowcaseDemo/MeetingCaptureWebApp/Helpers/GraphService.cs
@@ -178,7 +178,7 @@ namespace MeetingCaptureWebApp.Helpers
         }
 
         // Send an email message from the current user.
-        public static async Task SendEmail(GraphServiceClient graphClient, IHostingEnvironment hostingEnvironment, string recipients, HttpContext httpContext)
+        public static async Task SendEmail(GraphServiceClient graphClient, IWebHostEnvironment hostingEnvironment, string recipients, HttpContext httpContext)
         {
             if (recipients == null) return;
 

--- a/Source/FY19GraphShowcaseDemo/MeetingCaptureWebApp/Startup.cs
+++ b/Source/FY19GraphShowcaseDemo/MeetingCaptureWebApp/Startup.cs
@@ -15,6 +15,9 @@ using MeetingCaptureWebApp.Helpers;
 using MeetingCaptureWebApp.Data;
 using MeetingCaptureWebApp.Services;
 using System;
+using Microsoft.AspNetCore.Diagnostics;
+using Newtonsoft.Json;
+using Microsoft.AspNetCore.Http;
 
 namespace MeetingCaptureWebApp
 {
@@ -63,7 +66,24 @@ namespace MeetingCaptureWebApp
             }
             else
             {
-                app.UseExceptionHandler("/Home/Error");
+                //Handle exceptions and return a 500 http response with the exception message
+                app.UseExceptionHandler(appBuilder =>
+                {
+                    appBuilder.Run(async context =>
+                    {
+                        var exceptionHandlerFeature = context.Features.Get<IExceptionHandlerFeature>();
+                        if (exceptionHandlerFeature != null)
+                        {
+                            var exceptionMessage = exceptionHandlerFeature.Error.Message;
+
+                            var result = JsonConvert.SerializeObject(exceptionMessage);
+                            context.Response.StatusCode = 500;
+                            context.Response.ContentType = "application/json";
+                            await context.Response.WriteAsync(result);
+                        }
+                    });
+                });
+
                 // The default HSTS value is 30 days. You may want to change this for production scenarios, see https://aka.ms/aspnetcore-hsts.
                 app.UseHsts();
             }


### PR DESCRIPTION
1. Fix Graph API error by updating the call for creating onlineMeeting object. Currently, "graph.microsoft.com/beta/app/onlineMeetings" with an application token is used to create an onlineMeeting object. It is deprecated as stated in the Graph API documentation: _https://docs.microsoft.com/en-us/graph/api/application-post-onlinemeetings?view=graph-rest-beta&tabs=http_
_"Note: The /app or /communications path with an application token is deprecated. Going forward, use the /me path with a user token to create online meetings."_
This caused the http request to fail and creation of Meeting inside of Teams returns an error. 
Fixed by using the Graph SDK:
` await GraphClient.Me.OnlineMeetings.Request().AddAsync(onlineMeeting);`
2. Use IWebHostEnvironment instead of deprecated IHostingEnvironment. 
3. Add exception handling pipeline returning exception messages with 500 http responses.